### PR TITLE
lineage: Consider techpack/audio when generating kernel headers [ for support building with 4.9 kernul ]

### DIFF
--- a/build/soong/Android.bp
+++ b/build/soong/Android.bp
@@ -34,7 +34,7 @@ custom_generator {
 
     // Sources for dependency tracking
     dep_root: "$(TARGET_KERNEL_SOURCE)",
-    dep_files: [ "Makefile", "include/**/*", "arch/$(KERNEL_ARCH)/include/**/*"],
+    dep_files: [ "Makefile", "include/**/*", "arch/$(KERNEL_ARCH)/include/**/*", "techpack/audio/include/**/*"],
 }
 
 cc_library_headers {


### PR DESCRIPTION
 * New fancy kernels have techpack modules and we need to
   account for headers of those modules.

Change-Id: I4da9606d5933209287dd5e881f06ee1e39443f70