### PR TITLE
vendor: add veux to official device list

### DIFF
--- a/superior.devices
+++ b/superior.devices
@@ -6,3 +6,4 @@ Mi439
 spes
 alioth
 lava
+veux


### PR DESCRIPTION
This commit will add poco x4 Pro 5G ( veux ) to official device list